### PR TITLE
Refactor plugin name and update configuration for Kr2FA; enhance command messaging with prefixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Install Kr2FA using one of the following methods:
    /2fa <6-digit-code>
    ```
 
-###  Configuration
+### Configuration
 
 Edit `plugins/Velocity2FA/config.json` after first run. New option:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KICAgIDxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgODAwIDIwMCI+CiAgICAgICAgPGRlZnM+CiAgICAgICAgICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iYmctZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICAgICAgICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3R5bGU9InN0b3AtY29sb3I6IzQxNThEMDtzdG9wLW9wYWNpdHk6MSIgLz4KICAgICAgICAgICAgICAgIDxzdG9wIG9mZnNldD0iNTAlIiBzdHlsZT0ic3RvcC1jb2xvcjojQzg1MEMwO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICAgICAgICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZDQzcwO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICAgICAgICA8L2xpbmVhckdyYWRpZW50PgogICAgICAgICAgICA8ZmlsdGVyIGlkPSJzaGFkb3ciPgogICAgICAgICAgICAgICAgPGZlRHJvcFNoYWRvdyBkeD0iMCIgZHk9IjQiIHN0ZERldmlhdGlvbj0iNCIgZmxvb2Qtb3BhY2l0eT0iMC4yNSIgLz4KICAgICAgICAgICAgPC9maWx0ZXI+CiAgICAgICAgPC9kZWZzPgogICAgICAgIDxyZWN0IHdpZHRoPSI4MDAiIGhlaWdodD0iMjAwIiBmaWxsPSJ1cmwoI2JnLWdyYWRpZW50KSIgcng9IjE1IiByeT0iMTUiLz4KICAgICAgICA8dGV4dCB4PSI0MDAiIHk9IjEwMCIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjQ4IgogICAgICAgIGZvbnQtd2VpZ2h0PSJib2xkIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIGZpbGw9IiNGRkZGRkYiIGZpbHRlcj0idXJsKCNzaGFkb3cpIj5LUjJGQTwvdGV4dD4KICAgIDwvc3ZnPg==" alt="kr2fa-banner" width="800">
+	<img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KICAgIDxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgODAwIDIwMCI+CiAgICAgICAgPGRlZnM+CiAgICAgICAgICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iYmctZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICAgICAgICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3R5bGU9InN0b3AtY29sb3I6IzQxNThEMDtzdG9wLW9wYWNpdHk6MSIgLz4KICAgICAgICAgICAgICAgIDxzdG9wIG9mZnNldD0iNTAlIiBzdHlsZT0ic3RvcC1jb2xvcjojQzg1MEMwO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICAgICAgICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZDQzcwO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICAgICAgICA8L2xpbmVhckdyYWRpZW50PgogICAgICAgICAgICA8ZmlsdGVyIGlkPSJzaGFkb3ciPgogICAgICAgICAgICAgICAgPGZlRHJvcFNoYWRvdyBkeD0iMCIgZHk9IjQiIHN0ZERldmlhdGlvbj0iNCIgZmxvb2Qtb3BhY2l0eT0iMC4yNSIgLz4KICAgICAgICAgICAgPC9maWx0ZXI+CiAgICAgICAgPC9kZWZzPgogICAgICAgIDxyZWN0IHdpZHRoPSI4MDAiIGhlaWdodD0iMjAwIiBmaWxsPSJ1cmwoI2JnLWdyYWRpZW50KSIgcng9IjE1IiByeT0iMTUiLz4KICAgICAgICA8dGV4dCB4PSI0MDAiIHk9IjEwMCIgZm9udC1mYW1pbHk9IkFyaWFsLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjQ4IgogICAgICAgIGZvbnQtd2VpZ2h0PSJib2xkIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIgogICAgICAgIGZpbGw9IiNGRkZGRkYiIGZpbHRlcj0idXJsKCNzaGFkb3cpIj5LUjJGQTwvdGV4dD4KICAgIDwvc3ZnPg==" alt="kr2fa-banner" width="800"></p>
 	
 <p align="left">
 	<em><code>A lightweight staff-only 2FA plugin for Velocity 3 (MC 1.21.x). Premium-only (online-mode) friendly.</code></em>
@@ -33,7 +33,7 @@
 
 ##  Overview
 
-Kr2FA (Velocity2FA) is a Two-Factor Authentication plugin explicitly designed for Minecraft Velocity proxy servers. It provides an additional layer of security for staff members by requiring TOTP-based authentication (compatible with Google Authenticator/Authy) before granting access to backend servers. The plugin blocks staff from connecting to game servers or executing commands until they complete 2FA verification, preventing unauthorized access even if credentials are compromised.
+Kr2FA is a Two-Factor Authentication plugin explicitly designed for Minecraft Velocity proxy servers. It provides an additional layer of security for staff members by requiring TOTP-based authentication (compatible with Google Authenticator/Authy) before granting access to backend servers. The plugin blocks staff from connecting to game servers or executing commands until they complete 2FA verification, preventing unauthorized access even if credentials are compromised.
 
 ---
 
@@ -43,10 +43,12 @@ Kr2FA (Velocity2FA) is a Two-Factor Authentication plugin explicitly designed fo
 - **TOTP Authentication**: Uses industry-standard Time-based One-Time Passwords compatible with Google Authenticator, Authy, and similar apps
 - **Server Connection Blocking**: Blocks staff from joining backend servers until 2FA verification is complete
 - **Command Restriction**: Blocks all commands (except `/2fa`) until authentication is successful
-- **Persistent Secrets**: Securely stores TOTP secrets in `plugins/Velocity2FA/secrets.json`
+- **Persistent Secrets**: Securely stores TOTP secrets in `plugins/Kr2FA/secrets.json`
 - **Session Cache**: Configurable session duration to avoid re-verifying too often (default 12h)
 - **Admin Management**: Dedicated admin command (`/2fa-admin`) for managing staff 2FA settings
 - **Limbo Server Support**: Allows players to connect to a designated limbo/lobby server while pending authentication
+
+- **Configurable Message Prefix**: Prepend a custom, editable prefix to all plugin messages for clear branding
 
 ---
 
@@ -215,7 +217,7 @@ Kr2FA (Velocity2FA) is a Two-Factor Authentication plugin explicitly designed fo
 
 Before getting started with Kr2FA, ensure your runtime environment meets the following requirements:
 
-- **Programming Language:** Java 21 or higher
+- **Programming Language:** Java 21 or higher (build may require matching JDK)
 - **Build Tool:** Maven 3.6+
 - **Server:** Velocity 3.1.1+ proxy server
 
@@ -266,6 +268,22 @@ Install Kr2FA using one of the following methods:
    ```sh
    /2fa <6-digit-code>
    ```
+
+###  Configuration
+
+Edit `plugins/Velocity2FA/config.json` after first run. New option:
+
+- `messagePrefix`: A short tag prepended to all player/console messages sent by the plugin. Default: `[Kr2FA]`.
+
+Example snippet:
+```json
+{
+	"serverName": "Proxy-01",
+	"limboServer": "Hub",
+	"messagePrefix": "[Kr2FA]",
+	"issuerName": "Velocity2FA"
+}
+```
 
 ###  Testing
 Run the test suite using the following command:

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Install Kr2FA using one of the following methods:
 
 4. Copy the generated JAR to your Velocity plugins folder:
 ```sh
-❯ cp target/Velocity2FA-*.jar /path/to/velocity/plugins/
+❯ cp target/Kr2FA-*.jar /path/to/velocity/plugins/
 ```
 
 
@@ -254,11 +254,6 @@ Install Kr2FA using one of the following methods:
 2. Grant staff members the appropriate permission (any of the following will work):
    ```sh
    /lp group staff permission set staff true
-   # OR use any of these alternatives:
-   # /lp group staff permission set moderator true
-   # /lp group staff permission set admin true
-   # /lp group staff permission set helper true
-   # /lp group staff permission set velocity2fa.staff true
    ```
 3. When staff members first join, they'll be prompted to set up 2FA:
    ```sh

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Example snippet:
 	"serverName": "Proxy-01",
 	"limboServer": "Hub",
 	"messagePrefix": "[Kr2FA]",
-	"issuerName": "Velocity2FA"
+	"issuerName": "Kr2FA"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,16 +5,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.queazified</groupId>
-    <artifactId>velocity-2fa</artifactId>
+    <artifactId>kr2fa</artifactId>
     <version>1.0.56</version>
     <packaging>jar</packaging>
 
-    <name>Velocity2FA</name>
+    <name>Kr2FA</name>
     <description>Two-Factor Authentication plugin for Velocity - Staff security enhancement</description>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <velocity.version>3.1.1</velocity.version>
     </properties>
@@ -87,8 +87,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.velocitypowered</groupId>

--- a/src/main/java/com/queazified/velocity2fa/AdminCommand.java
+++ b/src/main/java/com/queazified/velocity2fa/AdminCommand.java
@@ -249,7 +249,7 @@ public class AdminCommand implements SimpleCommand {
             .filter(this::hasStaffPermission)
             .count();
 
-        plugin.sendPrefixed(source, Component.text("=== Velocity2FA Statistics ===")
+        plugin.sendPrefixed(source, Component.text("=== Kr2FA Statistics ===")
             .color(NamedTextColor.GOLD));
         plugin.sendPrefixed(source, Component.text("Total 2FA Enabled: " + totalEnabled)
             .color(NamedTextColor.YELLOW));

--- a/src/main/java/com/queazified/velocity2fa/AdminCommand.java
+++ b/src/main/java/com/queazified/velocity2fa/AdminCommand.java
@@ -77,7 +77,7 @@ public class AdminCommand implements SimpleCommand {
     }
 
     private void showAdminHelp(CommandSource source) {
-        plugin.sendPrefixed(source, Component.text("=== Velocity2FA Admin Commands ===")
+        plugin.sendPrefixed(source, Component.text("=== Kr2FA Admin Commands ===")
             .color(NamedTextColor.GOLD));
         plugin.sendPrefixed(source, Component.text("/2fa-admin disable <player> [code] - Disable player's 2FA (with verification)")
             .color(NamedTextColor.YELLOW));

--- a/src/main/java/com/queazified/velocity2fa/AdminCommand.java
+++ b/src/main/java/com/queazified/velocity2fa/AdminCommand.java
@@ -26,7 +26,7 @@ public class AdminCommand implements SimpleCommand {
         String[] args = invocation.arguments();
 
         if (!source.hasPermission("velocity2fa.admin")) {
-            source.sendMessage(Component.text("No permission.")
+            plugin.sendPrefixed(source, Component.text("No permission.")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -39,7 +39,7 @@ public class AdminCommand implements SimpleCommand {
         switch (args[0].toLowerCase()) {
             case "disable":
                 if (args.length < 2) {
-                    source.sendMessage(Component.text("Usage: /2fa-admin disable <player> [code]")
+                    plugin.sendPrefixed(source, Component.text("Usage: /2fa-admin disable <player> [code]")
                         .color(NamedTextColor.RED));
                     return;
                 }
@@ -47,7 +47,7 @@ public class AdminCommand implements SimpleCommand {
                 break;
             case "force-disable":
                 if (args.length < 2) {
-                    source.sendMessage(Component.text("Usage: /2fa-admin force-disable <player>")
+                    plugin.sendPrefixed(source, Component.text("Usage: /2fa-admin force-disable <player>")
                         .color(NamedTextColor.RED));
                     return;
                 }
@@ -55,7 +55,7 @@ public class AdminCommand implements SimpleCommand {
                 break;
             case "status":
                 if (args.length < 2) {
-                    source.sendMessage(Component.text("Usage: /2fa-admin status <player>")
+                    plugin.sendPrefixed(source, Component.text("Usage: /2fa-admin status <player>")
                         .color(NamedTextColor.RED));
                     return;
                 }
@@ -77,28 +77,28 @@ public class AdminCommand implements SimpleCommand {
     }
 
     private void showAdminHelp(CommandSource source) {
-        source.sendMessage(Component.text("=== Velocity2FA Admin Commands ===")
+        plugin.sendPrefixed(source, Component.text("=== Velocity2FA Admin Commands ===")
             .color(NamedTextColor.GOLD));
-        source.sendMessage(Component.text("/2fa-admin disable <player> [code] - Disable player's 2FA (with verification)")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin disable <player> [code] - Disable player's 2FA (with verification)")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("/2fa-admin force-disable <player> - Force disable without verification")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin force-disable <player> - Force disable without verification")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("/2fa-admin status <player> - Check player's 2FA status")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin status <player> - Check player's 2FA status")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("/2fa-admin list - List all players with 2FA enabled")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin list - List all players with 2FA enabled")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("/2fa-admin stats - Show 2FA usage statistics")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin stats - Show 2FA usage statistics")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("/2fa-admin reload - Reload plugin configuration")
+        plugin.sendPrefixed(source, Component.text("/2fa-admin reload - Reload plugin configuration")
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("==================================")
+        plugin.sendPrefixed(source, Component.text("==================================")
             .color(NamedTextColor.GOLD));
     }
 
     private void disablePlayerTwoFactor(CommandSource source, String playerName, String code) {
         Optional<Player> playerOpt = plugin.getServer().getPlayer(playerName);
         if (!playerOpt.isPresent()) {
-            source.sendMessage(Component.text("Player not found or not online!")
+            plugin.sendPrefixed(source, Component.text("Player not found or not online!")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -107,7 +107,7 @@ public class AdminCommand implements SimpleCommand {
         UUID targetUuid = target.getUniqueId();
 
         if (!plugin.getTwoFactorManager().hasSecretKey(targetUuid)) {
-            source.sendMessage(Component.text("Player " + playerName + " doesn't have 2FA enabled!")
+            plugin.sendPrefixed(source, Component.text("Player " + playerName + " doesn't have 2FA enabled!")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -116,7 +116,7 @@ public class AdminCommand implements SimpleCommand {
             // Verify the code before disabling
             boolean valid = plugin.getTwoFactorManager().verifyCode(targetUuid, code);
             if (!valid) {
-                source.sendMessage(Component.text("Invalid 2FA code! Cannot disable 2FA for " + playerName)
+                plugin.sendPrefixed(source, Component.text("Invalid 2FA code! Cannot disable 2FA for " + playerName)
                     .color(NamedTextColor.RED));
                 return;
             }
@@ -126,10 +126,10 @@ public class AdminCommand implements SimpleCommand {
         plugin.getAuthenticatedPlayers().remove(target.getUsername());
         plugin.getPendingAuthentication().remove(target.getUsername());
 
-        source.sendMessage(Component.text("Successfully disabled 2FA for " + playerName)
+        plugin.sendPrefixed(source, Component.text("Successfully disabled 2FA for " + playerName)
             .color(NamedTextColor.GREEN));
-        target.sendMessage(Component.text("Your 2FA has been disabled by an administrator.")
-            .color(NamedTextColor.YELLOW));
+        target.sendMessage(plugin.withPrefix(Component.text("Your 2FA has been disabled by an administrator.")
+            .color(NamedTextColor.YELLOW)));
 
         plugin.getLogger().info("Admin {} disabled 2FA for player {}", 
             source instanceof Player ? ((Player) source).getUsername() : "Console", playerName);
@@ -155,14 +155,14 @@ public class AdminCommand implements SimpleCommand {
                 }
             }
             if (targetUuid == null) {
-                source.sendMessage(Component.text("Player must be online for force-disable. Use regular disable with verification instead.")
+                plugin.sendPrefixed(source, Component.text("Player must be online for force-disable. Use regular disable with verification instead.")
                     .color(NamedTextColor.RED));
                 return;
             }
         }
 
         if (!plugin.getTwoFactorManager().hasSecretKey(targetUuid)) {
-            source.sendMessage(Component.text("Player " + targetName + " doesn't have 2FA enabled!")
+            plugin.sendPrefixed(source, Component.text("Player " + targetName + " doesn't have 2FA enabled!")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -171,12 +171,12 @@ public class AdminCommand implements SimpleCommand {
         plugin.getAuthenticatedPlayers().remove(targetName);
         plugin.getPendingAuthentication().remove(targetName);
 
-        source.sendMessage(Component.text("Force-disabled 2FA for " + targetName + " (no verification required)")
+        plugin.sendPrefixed(source, Component.text("Force-disabled 2FA for " + targetName + " (no verification required)")
             .color(NamedTextColor.GREEN));
         
         if (playerOpt.isPresent()) {
-            playerOpt.get().sendMessage(Component.text("Your 2FA has been force-disabled by an administrator.")
-                .color(NamedTextColor.RED));
+            playerOpt.get().sendMessage(plugin.withPrefix(Component.text("Your 2FA has been force-disabled by an administrator.")
+                .color(NamedTextColor.RED)));
         }
 
         plugin.getLogger().warn("Admin {} force-disabled 2FA for player {} without verification", 
@@ -186,7 +186,7 @@ public class AdminCommand implements SimpleCommand {
     private void showPlayerStatus(CommandSource source, String playerName) {
         Optional<Player> playerOpt = plugin.getServer().getPlayer(playerName);
         if (!playerOpt.isPresent()) {
-            source.sendMessage(Component.text("Player not found or not online!")
+            plugin.sendPrefixed(source, Component.text("Player not found or not online!")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -197,17 +197,17 @@ public class AdminCommand implements SimpleCommand {
         boolean isPending = plugin.getPendingAuthentication().contains(target.getUsername());
         boolean hasStaffPerm = hasStaffPermission(target);
 
-        source.sendMessage(Component.text("=== 2FA Status for " + playerName + " ===")
+        plugin.sendPrefixed(source, Component.text("=== 2FA Status for " + playerName + " ===")
             .color(NamedTextColor.GOLD));
-        source.sendMessage(Component.text("2FA Enabled: " + (has2FA ? "✓ Yes" : "✗ No"))
+        plugin.sendPrefixed(source, Component.text("2FA Enabled: " + (has2FA ? "✓ Yes" : "✗ No"))
             .color(has2FA ? NamedTextColor.GREEN : NamedTextColor.RED));
-        source.sendMessage(Component.text("Staff Permission: " + (hasStaffPerm ? "✓ Yes" : "✗ No"))
+        plugin.sendPrefixed(source, Component.text("Staff Permission: " + (hasStaffPerm ? "✓ Yes" : "✗ No"))
             .color(hasStaffPerm ? NamedTextColor.GREEN : NamedTextColor.RED));
         
         if (has2FA) {
-            source.sendMessage(Component.text("Authenticated This Session: " + (isAuthenticated ? "✓ Yes" : "✗ No"))
+            plugin.sendPrefixed(source, Component.text("Authenticated This Session: " + (isAuthenticated ? "✓ Yes" : "✗ No"))
                 .color(isAuthenticated ? NamedTextColor.GREEN : NamedTextColor.RED));
-            source.sendMessage(Component.text("Pending Authentication: " + (isPending ? "⚠ Yes" : "✓ No"))
+            plugin.sendPrefixed(source, Component.text("Pending Authentication: " + (isPending ? "⚠ Yes" : "✓ No"))
                 .color(isPending ? NamedTextColor.YELLOW : NamedTextColor.GREEN));
         }
     }
@@ -220,13 +220,13 @@ public class AdminCommand implements SimpleCommand {
 
         int totalUsers = plugin.getTwoFactorManager().getTotalEnabledUsers();
 
-        source.sendMessage(Component.text("=== Players with 2FA Enabled ===")
+        plugin.sendPrefixed(source, Component.text("=== Players with 2FA Enabled ===")
             .color(NamedTextColor.GOLD));
-        source.sendMessage(Component.text("Total: " + totalUsers + " | Online: " + onlineUsers.size())
+        plugin.sendPrefixed(source, Component.text("Total: " + totalUsers + " | Online: " + onlineUsers.size())
             .color(NamedTextColor.YELLOW));
 
         if (!onlineUsers.isEmpty()) {
-            source.sendMessage(Component.text("Online users with 2FA:")
+            plugin.sendPrefixed(source, Component.text("Online users with 2FA:")
                 .color(NamedTextColor.AQUA));
             for (String username : onlineUsers) {
                 Long expiry = plugin.getAuthenticatedPlayers().get(username);
@@ -234,7 +234,7 @@ public class AdminCommand implements SimpleCommand {
                 boolean pending = plugin.getPendingAuthentication().contains(username);
                 
                 String status = authenticated ? " §a✓" : (pending ? " §e⚠" : " §c✗");
-                source.sendMessage(Component.text("- " + username + status)
+                plugin.sendPrefixed(source, Component.text("- " + username + status)
                     .color(NamedTextColor.WHITE));
             }
         }
@@ -249,21 +249,21 @@ public class AdminCommand implements SimpleCommand {
             .filter(this::hasStaffPermission)
             .count();
 
-        source.sendMessage(Component.text("=== Velocity2FA Statistics ===")
+        plugin.sendPrefixed(source, Component.text("=== Velocity2FA Statistics ===")
             .color(NamedTextColor.GOLD));
-        source.sendMessage(Component.text("Total 2FA Enabled: " + totalEnabled)
+        plugin.sendPrefixed(source, Component.text("Total 2FA Enabled: " + totalEnabled)
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("Currently Authenticated: " + currentlyAuthenticated)
+        plugin.sendPrefixed(source, Component.text("Currently Authenticated: " + currentlyAuthenticated)
             .color(NamedTextColor.GREEN));
-        source.sendMessage(Component.text("Pending Authentication: " + pendingAuth)
+        plugin.sendPrefixed(source, Component.text("Pending Authentication: " + pendingAuth)
             .color(NamedTextColor.YELLOW));
-        source.sendMessage(Component.text("Total Online Staff: " + totalOnlineStaff)
+        plugin.sendPrefixed(source, Component.text("Total Online Staff: " + totalOnlineStaff)
             .color(NamedTextColor.AQUA));
     }
 
     private void reloadPlugin(CommandSource source) {
         plugin.getConfigManager().reload();
-        source.sendMessage(Component.text("Velocity2FA configuration reloaded!")
+        plugin.sendPrefixed(source, Component.text("Velocity2FA configuration reloaded!")
             .color(NamedTextColor.GREEN));
     }
 

--- a/src/main/java/com/queazified/velocity2fa/ConfigManager.java
+++ b/src/main/java/com/queazified/velocity2fa/ConfigManager.java
@@ -89,7 +89,8 @@ public class ConfigManager {
     public static class Config {
     public String serverName = "Proxy-01";
     public String limboServer = "Hub"; // Server name for unauthenticated staff
-        public String issuerName = "Velocity2FA";
+        public String messagePrefix = "[Kr2FA]";
+        public String issuerName = "Kr2FA";
         public boolean enforceFor2FA = true;
         public boolean requireCodeOnJoin = true;
         public List<String> staffPermissions = Arrays.asList(

--- a/src/main/java/com/queazified/velocity2fa/TwoFactorCommand.java
+++ b/src/main/java/com/queazified/velocity2fa/TwoFactorCommand.java
@@ -24,7 +24,7 @@ public class TwoFactorCommand implements SimpleCommand {
         String[] args = invocation.arguments();
 
         if (!(source instanceof Player)) {
-            source.sendMessage(Component.text("Only players can use this command.")
+            plugin.sendPrefixed(source, Component.text("Only players can use this command.")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -43,7 +43,7 @@ public class TwoFactorCommand implements SimpleCommand {
             case "verify":
             case "auth":
                 if (args.length < 2) {
-                    player.sendMessage(Component.text("Usage: /2fa verify <code>")
+                    plugin.sendPrefixed(player, Component.text("Usage: /2fa verify <code>")
                         .color(NamedTextColor.RED));
                     return;
                 }
@@ -63,19 +63,19 @@ public class TwoFactorCommand implements SimpleCommand {
     }
 
     private void showHelp(Player player) {
-        player.sendMessage(Component.text("---------- 2FA Commands ----------")
+        plugin.sendPrefixed(player, Component.text("---------- 2FA Commands ----------")
             .color(NamedTextColor.GOLD));
-        player.sendMessage(Component.text("/2fa setup - Set up 2FA for your account")
+        plugin.sendPrefixed(player, Component.text("/2fa setup - Set up 2FA for your account")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("/2fa <code> - Verify your 2FA code")
+        plugin.sendPrefixed(player, Component.text("/2fa <code> - Verify your 2FA code")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("/2fa verify <code> - Verify your 2FA code")
+        plugin.sendPrefixed(player, Component.text("/2fa verify <code> - Verify your 2FA code")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("/2fa disable - Disable 2FA (requires current code)")
+        plugin.sendPrefixed(player, Component.text("/2fa disable - Disable 2FA (requires current code)")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("/2fa status - Check your 2FA status")
+        plugin.sendPrefixed(player, Component.text("/2fa status - Check your 2FA status")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("----------    Kr2FA     ----------")
+        plugin.sendPrefixed(player, Component.text("----------    Kr2FA     ----------")
             .color(NamedTextColor.GOLD));
     }
 
@@ -83,7 +83,7 @@ public class TwoFactorCommand implements SimpleCommand {
         // Check if player has staff permission
         if (!hasStaffPermission(player)) {
             try {
-                player.sendMessage(Component.text("You don't have permission to use 2FA!")
+                plugin.sendPrefixed(player, Component.text("You don't have permission to use 2FA!")
                     .color(NamedTextColor.RED));
             } catch (Exception e) {
                 // Ignore system chat errors
@@ -93,7 +93,7 @@ public class TwoFactorCommand implements SimpleCommand {
 
         if (plugin.getTwoFactorManager().hasSecretKey(player.getUniqueId())) {
             try {
-                player.sendMessage(Component.text("You already have 2FA enabled! Use /2fa disable to remove it.")
+                plugin.sendPrefixed(player, Component.text("You already have 2FA enabled! Use /2fa disable to remove it.")
                     .color(NamedTextColor.RED));
             } catch (Exception e) {
                 // Ignore system chat errors
@@ -106,16 +106,16 @@ public class TwoFactorCommand implements SimpleCommand {
 
         if (player.isActive()) {
             try {
-                player.sendMessage(Component.text("---------- 2FA Setup ----------")
+                plugin.sendPrefixed(player, Component.text("---------- 2FA Setup ----------")
                     .color(NamedTextColor.GOLD));
 
-                player.sendMessage(Component.text("1. Install an authenticator app (Google Authenticator, Microsoft Authenticator, etc.)")
+                plugin.sendPrefixed(player, Component.text("1. Install an authenticator app (Google Authenticator, Microsoft Authenticator, etc.)")
                     .color(NamedTextColor.YELLOW));
 
-                player.sendMessage(Component.text("2. Enter the secret manually into your Authenticator:")
+                plugin.sendPrefixed(player, Component.text("2. Enter the secret manually into your Authenticator:")
                     .color(NamedTextColor.YELLOW));
 
-                player.sendMessage(Component.text("Secret Key: " + secretKey)
+                plugin.sendPrefixed(player, Component.text("Secret Key: " + secretKey)
                     .color(NamedTextColor.GREEN));
 
                 // Convert the otpauth URI to an HTTPS QR image URL so clicking opens in a browser.
@@ -128,14 +128,14 @@ public class TwoFactorCommand implements SimpleCommand {
                         .append(Component.text("Click here")
                             .color(NamedTextColor.AQUA)
                             .clickEvent(ClickEvent.openUrl(qrImageUrl)));
-                    player.sendMessage(qrComponent);
+                    plugin.sendPrefixed(player, qrComponent);
                 } catch (Exception e) {
                     // Fallback: send the raw otpauth URI as plain text (manual entry still possible)
-                    player.sendMessage(Component.text("QR: " + qrUrl)
+                    plugin.sendPrefixed(player, Component.text("QR: " + qrUrl)
                         .color(NamedTextColor.AQUA));
                 }
 
-                player.sendMessage(Component.text("3. After setup, use /2fa <code> to verify and complete setup")
+                plugin.sendPrefixed(player, Component.text("3. After setup, use /2fa <code> to verify and complete setup")
                     .color(NamedTextColor.YELLOW));
             } catch (Exception e) {
                 // Ignore system chat errors
@@ -145,7 +145,7 @@ public class TwoFactorCommand implements SimpleCommand {
 
     private void verifyCode(Player player, String code) {
         if (!plugin.getTwoFactorManager().hasSecretKey(player.getUniqueId())) {
-            player.sendMessage(Component.text("You don't have 2FA set up! Use /2fa setup first.")
+            plugin.sendPrefixed(player, Component.text("You don't have 2FA set up! Use /2fa setup first.")
                 .color(NamedTextColor.RED));
             return;
         }
@@ -158,12 +158,12 @@ public class TwoFactorCommand implements SimpleCommand {
             plugin.getAuthenticatedPlayers().put(player.getUsername(), expiry);
             plugin.getPendingAuthentication().remove(player.getUsername());
             
-            player.sendMessage(Component.text("2FA verification successful! You can now access servers.")
+            plugin.sendPrefixed(player, Component.text("2FA verification successful! You can now access servers.")
                 .color(NamedTextColor.GREEN));
             
             plugin.getLogger().info("Player {} successfully authenticated with 2FA", player.getUsername());
         } else {
-            player.sendMessage(Component.text("Invalid 2FA code! Please try again.")
+            plugin.sendPrefixed(player, Component.text("Invalid 2FA code! Please try again.")
                 .color(NamedTextColor.RED));
             
             plugin.getLogger().warn("Player {} failed 2FA authentication", player.getUsername());
@@ -177,9 +177,9 @@ public class TwoFactorCommand implements SimpleCommand {
             return;
         }
 
-        player.sendMessage(Component.text("To disable 2FA, please provide your current 2FA code:")
+        plugin.sendPrefixed(player, Component.text("To disable 2FA, please provide your current 2FA code:")
             .color(NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("Use: /2fa-admin disable " + player.getUsername() + " <code>")
+        plugin.sendPrefixed(player, Component.text("Use: /2fa-admin disable " + player.getUsername() + " <code>")
             .color(NamedTextColor.YELLOW));
     }
 
@@ -189,7 +189,7 @@ public class TwoFactorCommand implements SimpleCommand {
         boolean isAuthenticated = expiry != null && expiry > System.currentTimeMillis();
         boolean isPending = plugin.getPendingAuthentication().contains(player.getUsername());
 
-        player.sendMessage(Component.text("=== Your 2FA Status ===")
+        plugin.sendPrefixed(player, Component.text("=== Your 2FA Status ===")
             .color(NamedTextColor.GOLD));
         player.sendMessage(Component.text("2FA Enabled: " + (has2FA ? "✓ Yes" : "✗ No"))
             .color(has2FA ? NamedTextColor.GREEN : NamedTextColor.RED));
@@ -197,13 +197,13 @@ public class TwoFactorCommand implements SimpleCommand {
             .color(hasStaffPermission(player) ? NamedTextColor.GREEN : NamedTextColor.RED));
         
         if (has2FA) {
-            player.sendMessage(Component.text("Authenticated This Session: " + (isAuthenticated ? "✓ Yes" : "✗ No"))
+            plugin.sendPrefixed(player, Component.text("Authenticated This Session: " + (isAuthenticated ? "✓ Yes" : "✗ No"))
                 .color(isAuthenticated ? NamedTextColor.GREEN : NamedTextColor.RED));
-            player.sendMessage(Component.text("Pending Authentication: " + (isPending ? "⚠ Yes" : "✓ No"))
+            plugin.sendPrefixed(player, Component.text("Pending Authentication: " + (isPending ? "⚠ Yes" : "✓ No"))
                 .color(isPending ? NamedTextColor.YELLOW : NamedTextColor.GREEN));
             if (isAuthenticated && expiry != null) {
                 long minsLeft = (expiry - System.currentTimeMillis()) / 60000L;
-                player.sendMessage(Component.text("Session expires in: " + minsLeft + " min")
+                plugin.sendPrefixed(player, Component.text("Session expires in: " + minsLeft + " min")
                     .color(NamedTextColor.AQUA));
             }
         }

--- a/src/main/java/com/queazified/velocity2fa/TwoFactorCommand.java
+++ b/src/main/java/com/queazified/velocity2fa/TwoFactorCommand.java
@@ -191,9 +191,9 @@ public class TwoFactorCommand implements SimpleCommand {
 
         plugin.sendPrefixed(player, Component.text("=== Your 2FA Status ===")
             .color(NamedTextColor.GOLD));
-        player.sendMessage(Component.text("2FA Enabled: " + (has2FA ? "✓ Yes" : "✗ No"))
+        plugin.sendPrefixed(player, Component.text("2FA Enabled: " + (has2FA ? "✓ Yes" : "✗ No"))
             .color(has2FA ? NamedTextColor.GREEN : NamedTextColor.RED));
-        player.sendMessage(Component.text("Staff Permission: " + (hasStaffPermission(player) ? "✓ Yes" : "✗ No"))
+        plugin.sendPrefixed(player, Component.text("Staff Permission: " + (hasStaffPermission(player) ? "✓ Yes" : "✗ No"))
             .color(hasStaffPermission(player) ? NamedTextColor.GREEN : NamedTextColor.RED));
         
         if (has2FA) {

--- a/src/main/java/com/queazified/velocity2fa/TwoFactorManager.java
+++ b/src/main/java/com/queazified/velocity2fa/TwoFactorManager.java
@@ -82,12 +82,12 @@ public class TwoFactorManager {
 
     public String generateQRUrl(String username, String secret) {
         try {
-            String issuer = "Velocity2FA";
+            String issuer = "Kr2FA";
             return "otpauth://totp/" + java.net.URLEncoder.encode(issuer + ":" + username, "UTF-8") + 
                    "?secret=" + secret + "&issuer=" + java.net.URLEncoder.encode(issuer, "UTF-8");
         } catch (Exception e) {
             logger.error("Failed to generate QR URL for {}: {}", username, e.getMessage());
-            return "otpauth://totp/Velocity2FA:" + username + "?secret=" + secret + "&issuer=Velocity2FA";
+            return "otpauth://totp/Kr2FA:" + username + "?secret=" + secret + "&issuer=Kr2FA";
         }
     }
 

--- a/src/main/java/com/queazified/velocity2fa/Velocity2FA.java
+++ b/src/main/java/com/queazified/velocity2fa/Velocity2FA.java
@@ -13,6 +13,7 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.command.CommandSource;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Plugin(
     id = "velocity2fa",
-    name = "Velocity2FA",
+    name = "Kr2FA",
     version = "1.0.0",
     description = "Two-Factor Authentication for staff members",
     authors = {"Queazified"}
@@ -75,11 +76,11 @@ public class Velocity2FA {
                 server.getScheduler().buildTask(this, () -> {
                     try {
                         if (player.isActive()) {
-                            player.sendMessage(Component.text("=== 2FA AUTHENTICATION REQUIRED ===")
+                            sendPrefixed(player, Component.text("=== 2FA AUTHENTICATION REQUIRED ===")
                                 .color(NamedTextColor.RED));
-                            player.sendMessage(Component.text("Please enter your 2FA code using: /2fa <code>")
+                            sendPrefixed(player, Component.text("Please enter your 2FA code using: /2fa <code>")
                                 .color(NamedTextColor.YELLOW));
-                            player.sendMessage(Component.text("You cannot join servers until authenticated.")
+                            sendPrefixed(player, Component.text("You cannot join servers until authenticated.")
                                 .color(NamedTextColor.RED));
                         }
                     } catch (Exception msgEx) {
@@ -107,9 +108,9 @@ public class Velocity2FA {
                 if (!targetServer.equalsIgnoreCase(limboServer)) {
                     event.setResult(ServerPreConnectEvent.ServerResult.denied());
                     try {
-                        player.sendMessage(Component.text("You must authenticate with 2FA first! Use /2fa <code>")
+                        sendPrefixed(player, Component.text("You must authenticate with 2FA first! Use /2fa <code>")
                             .color(NamedTextColor.RED));
-                        player.sendMessage(Component.text("You may only join the lobby/limbo server until authenticated.")
+                        sendPrefixed(player, Component.text("You may only join the lobby/limbo server until authenticated.")
                             .color(NamedTextColor.YELLOW));
                     } catch (Exception msgEx) {
                         logger.warn("Failed to send 2FA message to player {}: {}", player.getUsername(), msgEx.getMessage());
@@ -147,9 +148,9 @@ public class Velocity2FA {
                 if (!isAllowedCommand) {
                     event.setResult(CommandExecuteEvent.CommandResult.denied());
                     try {
-                        player.sendMessage(Component.text("You must authenticate with 2FA first! Use /2fa <code>")
+                        sendPrefixed(player, Component.text("You must authenticate with 2FA first! Use /2fa <code>")
                             .color(NamedTextColor.RED));
-                        player.sendMessage(Component.text("Commands are blocked until you complete 2FA authentication.")
+                        sendPrefixed(player, Component.text("Commands are blocked until you complete 2FA authentication.")
                             .color(NamedTextColor.YELLOW));
                     } catch (Exception msgEx) {
                         logger.warn("Failed to send 2FA command block message to player {}: {}", player.getUsername(), msgEx.getMessage());
@@ -194,4 +195,20 @@ public class Velocity2FA {
     public ConfigManager getConfigManager() { return configManager; }
     public Map<String, Long> getAuthenticatedPlayers() { return authenticatedPlayers; }
     public Set<String> getPendingAuthentication() { return pendingAuthentication; }
+
+    // Prefix helpers
+    private Component prefixComponent() {
+        String prefix = configManager != null && configManager.getConfig() != null
+            ? configManager.getConfig().messagePrefix
+            : "[Kr2FA]";
+        return Component.text(prefix).color(NamedTextColor.GRAY).append(Component.text(" "));
+    }
+
+    public Component withPrefix(Component message) {
+        return prefixComponent().append(message);
+    }
+
+    public void sendPrefixed(CommandSource target, Component message) {
+        target.sendMessage(withPrefix(message));
+    }
 }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,7 +1,8 @@
 {
   "serverName": "Proxy-01",
   "limboServer": "Hub",
-  "issuerName": "Velocity2FA",
+  "messagePrefix": "[Kr2FA]",
+  "issuerName": "Kr2FA",
   "enforceFor2FA": true,
   "requireCodeOnJoin": true,
   "staffPermissions": ["velocity2fa.staff"],

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "velocity2fa",
-  "name": "Velocity2FA",
+  "name": "Kr2FA",
   "version": "1.0.0",
   "description": "Two-Factor Authentication plugin for staff members",
   "authors": [


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the Kr2FA plugin, focusing on branding consistency, configuration flexibility, and enhanced user messaging. The most significant changes are the rebranding from Velocity2FA to Kr2FA, the addition of a configurable message prefix for all plugin messages, and updates to the admin command to use the new prefixed messaging system.

**Branding and Naming Updates**
* Changed all references of "Velocity2FA" to "Kr2FA" in documentation, configuration, and build files, including the `artifactId`, `name`, and secret storage path (`pom.xml`, `README.md`). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R52)
* Updated plugin secret storage to use `plugins/Kr2FA/secrets.json` instead of the previous path.

**Configuration Improvements**
* Added a new `messagePrefix` option to `config.json` that allows customization of the prefix for all player and console messages sent by the plugin, with documentation and example provided in `README.md`.

**Admin Command Messaging Enhancements**
* Refactored all admin command messages in `AdminCommand.java` to use the new prefixed messaging method (`plugin.sendPrefixed` and `plugin.withPrefix`), ensuring consistent branding and clearer communication for both admins and players. [[1]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL29-R29) [[2]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL42-R58) [[3]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL80-R101) [[4]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL110-R110) [[5]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL119-R119) [[6]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL129-R132) [[7]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL158-R165) [[8]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL174-R179) [[9]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL189-R189) [[10]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL200-R210) [[11]](diffhunk://#diff-1ed1c3c7f9c55e17fd14a8e337895ae779a715c7633ac5f19147def73b2bef2cL223-R237)

**Build System Compatibility**
* Changed the Java compiler target/source version from 21 to 11 in `pom.xml` for broader compatibility, and updated the Maven compiler plugin configuration to use these properties. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R17) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L90-R91)

**Documentation Updates**
* Improved the `README.md` to reflect the new plugin name, configuration options, and clarified the required Java version for building. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L218-R220)

**Other minor changes**
* Added a `.vscode/settings.json` file to enable automatic null analysis for Java development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable messagePrefix option for message formatting (default "[Kr2FA]").
  * Plugin display/issuer name updated to "Kr2FA" everywhere users see it.

* **Chores**
  * Plugin renamed from Velocity2FA to Kr2FA.
  * Java compatibility adjusted to target Java 11.
  * All user-facing messages unified to use the configured prefix.

* **Documentation**
  * README updated with configuration examples, updated paths, and Java prerequisite clarification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->